### PR TITLE
makes FITDeveloperField definition and developer references strong

### DIFF
--- a/Sources/ObjcFIT/FITDeveloperFieldDef.mm
+++ b/Sources/ObjcFIT/FITDeveloperFieldDef.mm
@@ -17,8 +17,8 @@
 @interface FITDeveloperField ()
 
 @property(nonatomic, assign) fit::DeveloperField *fit_developer_field;
-@property(nonatomic, assign) FITFieldDescriptionMesg* definition;
-@property(nonatomic, assign) FITDeveloperDataIdMesg* developer;
+@property(nonatomic, strong) FITFieldDescriptionMesg* definition;
+@property(nonatomic, strong) FITDeveloperDataIdMesg* developer;
 
 @end
 


### PR DESCRIPTION
Accessing the a developer field's description or developer causes an `EXC_BAD_ACCESS` when processing a record message that has developer fields. Without the field's description, there is no way to determine the field index, or other properties of the value provided.